### PR TITLE
To Be Reviewed :)

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ This module will look for the Netlify CMS config file and extensions in the foll
 
 #### Netlify CMS `config.yml`
 
-You can specify a [custom configuration](https://www.netlifycms.org/docs/#configuration), that will be parsed and merged with the module's [netlify CMS options](#cmsconfig).
+You can specify a [custom configuration](https://www.netlifycms.org/docs/configuration-options/), that will be parsed and merged with the module's [netlify CMS options](#cmsconfig).
 
 You have to place the file in your Netlify CMS module config folder and name it `config.yml`.
 
@@ -69,7 +69,7 @@ This file can be changed while `nuxt dev` is running, and Netlify CMS will be up
 
 This module will look for [Netlify CMS extensions](https://github.com/netlify/netlify-cms/blob/master/docs/intro.md#customization) in \*.js files contained in Netlify CMS module config folder and subfolders, and include them in the CMS build.
 
-These are of two kinds, [Custom Previews](https://www.netlifycms.org/docs/customization/) and [Widgets](https://www.netlifycms.org/docs/extending/).
+These are of two kinds, [Custom Previews](https://www.netlifycms.org/docs/customization/) and [Widgets](https://www.netlifycms.org/docs/custom-widgets/).
 
 :information_source: The global variable `CMS` is available to these javascript files to reference the CMS object.
 


### PR DESCRIPTION
I have updated some URLs, although there's no current URL matching: the section for **#netlify-cms-extensions**.

```
[Netlify CMS extensions](https://github.com/netlify/netlify-cms/blob/master/docs/intro.md#customization)
```

Would this one be the equivalent?
https://www.netlifycms.org/docs/configuration-options/#collections

This paragraph needs to be rewritten, maybe?

Thank you very much for this module. I, indeed, want to give it a try! Nuxt+Netlify would be awesome!