### PR TITLE
Support Nuxt.js >= 2.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,6 +23,8 @@
     "dist"
   ],
   "dependencies": {
+    "extract-text-webpack-plugin": "^3.0.2",
+    "friendly-errors-webpack-plugin": "^1.7.0",
     "js-yaml": "^3.10.0",
     "needlepoint": "^1.0.5",
     "style-loader": "^0.23.0"
@@ -31,6 +33,7 @@
     "netlify-cms": ">=0.4.0"
   },
   "devDependencies": {
+    "@nuxt/common": "^2.3.4",
     "babel-cli": "^6.26.0",
     "babel-eslint": "^10.0.1",
     "babel-plugin-transform-decorators-legacy": "^1.3.4",
@@ -52,7 +55,7 @@
     "koa-static": "^5.0.0",
     "lint-staged": "^8.0.4",
     "netlify-cms": "2.1.3",
-    "nuxt": "^1.4.2",
+    "nuxt": "^2.0.0",
     "prettier": "^1.7.0",
     "request-promise-native": "^1.0.4",
     "standard-version": "^4.2.0"

--- a/package.json
+++ b/package.json
@@ -23,9 +23,9 @@
     "dist"
   ],
   "dependencies": {
-    "extract-text-webpack-plugin": "^3.0.2",
     "friendly-errors-webpack-plugin": "^1.7.0",
     "js-yaml": "^3.10.0",
+    "mini-css-extract-plugin": "^0.5.0",
     "needlepoint": "^1.0.5",
     "style-loader": "^0.23.0"
   },

--- a/src/module.js
+++ b/src/module.js
@@ -4,7 +4,7 @@ import { join } from "path";
 /* covered by nuxt */
 import { move } from "fs-extra";
 import _ from "lodash";
-import { Utils } from "nuxt";
+import { r, urlJoin } from "@nuxt/common";
 import chokidar from "chokidar";
 import pify from "pify";
 import webpack from "webpack";
@@ -137,7 +137,7 @@ export default function NetlifyCmsModule(moduleOptions) {
       path: config.adminPath,
       handler: async (req, res) => {
         if (this.nuxt.renderer.netlifyWebpackDevMiddleware) {
-          debug(`requesting url: ${Utils.urlJoin(config.adminPath, req.url)}`);
+          debug(`requesting url: ${urlJoin(config.adminPath, req.url)}`);
           await this.nuxt.renderer.netlifyWebpackDevMiddleware(req, res);
         }
         if (this.nuxt.renderer.netlifyWebpackHotMiddleware) {
@@ -147,7 +147,7 @@ export default function NetlifyCmsModule(moduleOptions) {
     });
 
     // Start watching config file
-    const patterns = [Utils.r(configManager.cmsConfigFileName)];
+    const patterns = [r(configManager.cmsConfigFileName)];
 
     const options = {
       ...this.options.watchers.chokidar,

--- a/src/webpack.config.js
+++ b/src/webpack.config.js
@@ -1,7 +1,7 @@
 import { existsSync } from "fs";
 import { resolve } from "path";
 
-import { Utils } from "nuxt";
+import { urlJoin } from "@nuxt/common";
 /* eslint-disable import/no-extraneous-dependencies */
 /* covered by nuxt */
 import webpack from "webpack";
@@ -16,11 +16,11 @@ export default function webpackNetlifyCmsConfig(
 ) {
   const ENTRY = resolve(__dirname, "../lib/entry");
   const BUILD_DIR = moduleConfig.buildDir;
-  const CHUNK_FILENAME = nuxtOptions.build.filenames.chunk;
-  const PUBLIC_PATH = Utils.urlJoin(
-    nuxtOptions.router.base,
-    moduleConfig.adminPath
-  );
+  const CHUNK_FILENAME = nuxtOptions.build.filenames.chunk({
+    isDev: nuxtOptions.dev,
+    isModern: nuxtOptions.modern
+  });
+  const PUBLIC_PATH = urlJoin(nuxtOptions.router.base, moduleConfig.adminPath);
   const EXTENSIONS_DIR = moduleConfig.moduleConfigDir;
   const PAGE_TITLE = moduleConfig.adminTitle;
   const PAGE_TEMPLATE = resolve(__dirname, "../lib/template", "index.html");
@@ -43,7 +43,7 @@ export default function webpackNetlifyCmsConfig(
       publicPath: PUBLIC_PATH
     },
     module: {
-      loaders: [
+      rules: [
         { test: /\.css$/, loader: "style-loader!css-loader" },
         {
           test: /\.(eot|svg|ttf|woff|woff2)$/,

--- a/src/webpack.config.js
+++ b/src/webpack.config.js
@@ -6,7 +6,7 @@ import { urlJoin } from "@nuxt/common";
 /* covered by nuxt */
 import webpack from "webpack";
 import HTMLPlugin from "html-webpack-plugin";
-import ExtractTextPlugin from "extract-text-webpack-plugin";
+import MiniCssExtractPlugin from "mini-css-extract-plugin";
 import FriendlyErrorsWebpackPlugin from "friendly-errors-webpack-plugin";
 
 export default function webpackNetlifyCmsConfig(
@@ -98,7 +98,7 @@ export default function webpackNetlifyCmsConfig(
     // Minify and optimize the JavaScript
     config.plugins.push(
       // CSS extraction
-      new ExtractTextPlugin({
+      new MiniCssExtractPlugin({
         filename: "style.[contenthash].css"
       }),
       // This is needed in webpack 2 for minify CSS


### PR DESCRIPTION
This PR aims at fixing the compatibility with Nuxt.js >= 2.0.0:

- New dependencies: `extract-text-webpack-plugin`, `friendly-errors-webpack-plugin` 
- New dev-dependency: `@nuxt/common`
- Replace usage of `r()` and `urlJoin()` from `nuxt` using the `@nuxt/common` package
- Update `webpack` config
    - Replace `module.loaders` with `module.rules`
    - Resolve `CHUNK_FILENAME` as a string, depending on Nuxt build configuration

This fixes issues #104 and #105.
This can be tested using the `@rmnclmnt/nuxt-netlify-cms` package.