### PR TITLE
Add extend option

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,8 +96,8 @@ adminTitle defines the html title of the page where Netlify CMS will be served.
 extend is a function you can use to customize webpack configuration.
 
 - Arguments:
-  1. The Webpack config object.
-  2. An object with the following keys (all boolean): `isDev`.
+  - The Webpack config object.
+  - An object with the following keys (all boolean): `isDev`.
 
 ### `cmsConfig`
 - Default: `{

--- a/README.md
+++ b/README.md
@@ -90,6 +90,15 @@ With nuxt default configuration, it will be served to `http://localhost:3000/adm
 
 adminTitle defines the html title of the page where Netlify CMS will be served.
 
+### `extend`
+- Default: `undefined`
+
+extend is a function you can use to customize webpack configuration.
+
+- Arguments:
+  1. The Webpack config object.
+  2. An object with the following keys (all boolean): `isDev`.
+
 ### `cmsConfig`
 - Default: `{
     media_folder: "static/uploads"

--- a/src/configManager.js
+++ b/src/configManager.js
@@ -16,6 +16,7 @@ const CMS_CONFIG_FILENAME = "config.yml";
 const DEFAULTS = {
   adminPath: "admin",
   adminTitle: "Content Manager",
+  extend: undefined,
   cmsConfig: {
     media_folder: "static/uploads"
   }

--- a/src/webpack.config.js
+++ b/src/webpack.config.js
@@ -130,5 +130,9 @@ export default function webpackNetlifyCmsConfig(
     );
   }
 
+  if (typeof moduleConfig.extend === 'function') {
+    moduleConfig.extend(config, { isDev: nuxtOptions.dev })
+  }
+
   return config;
 }


### PR DESCRIPTION
This option (like Nuxt [`build.extend`](https://nuxtjs.org/api/configuration-build/#extend) option) adds the ability to customize webpack configuration.